### PR TITLE
Use delegate ProxySelector if can't find route

### DIFF
--- a/src/main/java/com/palantir/docker/proxy/DockerProxyRule.java
+++ b/src/main/java/com/palantir/docker/proxy/DockerProxyRule.java
@@ -80,7 +80,10 @@ public class DockerProxyRule extends ExternalResource {
             originalProxySelector = ProxySelector.getDefault();
             dockerComposeRule.before();
             getNameServices().add(0, new DockerNameService(dockerContainerInfo));
-            ProxySelector.setDefault(new DockerProxySelector(dockerComposeRule.containers(), dockerContainerInfo));
+            ProxySelector.setDefault(new DockerProxySelector(
+                    dockerComposeRule.containers(),
+                    dockerContainerInfo,
+                    originalProxySelector));
         } catch (DockerExecutionException e) {
             if (e.getMessage().contains("declared as external")) {
                 throw new IllegalStateException(


### PR DESCRIPTION
Allows using multiple docker proxy rules at the same time (and existing proxies)