### PR TITLE
Handle stopping containers gracefully

### DIFF
--- a/src/main/java/com/palantir/docker/proxy/DockerProxySelector.java
+++ b/src/main/java/com/palantir/docker/proxy/DockerProxySelector.java
@@ -14,7 +14,6 @@ import java.net.ProxySelector;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.List;
-import java.util.Optional;
 
 public class DockerProxySelector extends ProxySelector {
     public static final String PROXY_CONTAINER_NAME = "proxy";
@@ -34,9 +33,8 @@ public class DockerProxySelector extends ProxySelector {
 
     @Override
     public List<Proxy> select(URI uri) {
-        Optional<String> containerIpForUriHost = containerInfo.getIpForHost(uri.getHost());
-        Optional<String> containerHostForUriHost = containerInfo.getHostForIp(uri.getHost());
-        if (containerIpForUriHost.isPresent() || containerHostForUriHost.isPresent()) {
+        String host = uri.getHost();
+        if (containerInfo.getIpForHost(host).isPresent() || containerInfo.getHostForIp(host).isPresent()) {
             return ImmutableList.of(new Proxy(Proxy.Type.SOCKS, proxyAddress));
         } else {
             return delegate.select(uri);

--- a/src/main/java/com/palantir/docker/proxy/NetworkBasedDockerContainerInfo.java
+++ b/src/main/java/com/palantir/docker/proxy/NetworkBasedDockerContainerInfo.java
@@ -23,6 +23,8 @@ public class NetworkBasedDockerContainerInfo implements DockerContainerInfo {
                 .mapToEntry(containerId -> DockerContainerInfoUtils.getAllNamesForContainerId(docker, containerId))
                 .filterValues(names -> names.contains(hostname))
                 .mapToValue((containerId, names) -> DockerContainerInfoUtils.getContainerIpFromId(docker, containerId))
+                .filterValues(Optional::isPresent)
+                .mapValues(Optional::get)
                 .values()
                 .findAny();
     }
@@ -31,6 +33,8 @@ public class NetworkBasedDockerContainerInfo implements DockerContainerInfo {
     public Optional<String> getHostForIp(String ip) {
         return StreamEx.of(DockerContainerInfoUtils.getContainerIdsOnNetwork(docker, networkName))
                 .mapToEntry(containerId -> DockerContainerInfoUtils.getContainerIpFromId(docker, containerId))
+                .filterValues(Optional::isPresent)
+                .mapValues(Optional::get)
                 .filterValues(ip::equals)
                 .keys()
                 .findAny();

--- a/src/main/java/com/palantir/docker/proxy/ProjectBasedDockerContainerInfo.java
+++ b/src/main/java/com/palantir/docker/proxy/ProjectBasedDockerContainerInfo.java
@@ -24,6 +24,8 @@ public class ProjectBasedDockerContainerInfo implements DockerContainerInfo {
                 .mapToEntry(containerId -> DockerContainerInfoUtils.getAllNamesForContainerId(docker, containerId))
                 .filterValues(names -> names.contains(hostname))
                 .mapToValue((containerId, names) -> DockerContainerInfoUtils.getContainerIpFromId(docker, containerId))
+                .filterValues(Optional::isPresent)
+                .mapValues(Optional::get)
                 .values()
                 .findAny();
     }
@@ -32,6 +34,8 @@ public class ProjectBasedDockerContainerInfo implements DockerContainerInfo {
     public Optional<String> getHostForIp(String ip) {
         return StreamEx.of(DockerContainerInfoUtils.getContainerIdsInDockerComposeProject(docker, projectName))
                 .mapToEntry(containerId -> DockerContainerInfoUtils.getContainerIpFromId(docker, containerId))
+                .filterValues(Optional::isPresent)
+                .mapValues(Optional::get)
                 .filterValues(ip::equals)
                 .keys()
                 .findAny();

--- a/src/test/java/com/palantir/docker/proxy/DockerContainerInfoUtilsTest.java
+++ b/src/test/java/com/palantir/docker/proxy/DockerContainerInfoUtilsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.docker.proxy;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.palantir.docker.compose.execution.DockerExecutable;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+public class DockerContainerInfoUtilsTest {
+    private static final String CONTAINER_ID = "container-id";
+    private static final String IP_FORMAT_STRING = "{{ range .NetworkSettings.Networks }}{{ .IPAddress }}{{ end }}";
+
+    private final Process response = mock(Process.class);
+    private final DockerExecutable dockerExecutable = mock(DockerExecutable.class);
+
+    @Test
+    public void getContainerIpFromIdDoesNotThrowWhenContainerIsStopped() throws IOException, InterruptedException {
+        when(response.getInputStream()).thenReturn(getDockerOutputForStoppedContainer());
+        when(response.waitFor(anyLong(), any(TimeUnit.class))).thenReturn(true);
+        when(response.exitValue()).thenReturn(0);
+        when(dockerExecutable.execute("inspect", "--format", IP_FORMAT_STRING, CONTAINER_ID)).thenReturn(response);
+
+        Optional<String> ip = DockerContainerInfoUtils.getContainerIpFromId(dockerExecutable, CONTAINER_ID);
+        assertFalse(ip.isPresent());
+    }
+
+    private InputStream getDockerOutputForStoppedContainer() {
+        return new ByteArrayInputStream("\n".getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
There is a race condition between getting the list of containers
belonging to a Docker Compose project and fetching the corresponding
IPs for each container, since a container can stop (and consequently
lose its IP) in the meantime.

We can deal with this race by making the code that fetches the IPs
expect stopped containers.