### PR TITLE
Ensure `InetSocketAddress` for the proxy is resolved

### DIFF
--- a/src/main/java/com/palantir/docker/proxy/DockerProxySelector.java
+++ b/src/main/java/com/palantir/docker/proxy/DockerProxySelector.java
@@ -24,9 +24,8 @@ public final class DockerProxySelector extends ProxySelector {
     private final ProxySelector delegate;
 
     public DockerProxySelector(Cluster containers, DockerContainerInfo containerInfo, ProxySelector delegate) {
-        // ip's don't need resolution, yet without using the {@code InetSocketAddress} constructor, calling
-        // {@code InetSocketAddress#getAddress} returns {@code null} making the proxy unusable in certain downstream
-        // libraries.
+        // We can't call InetSocketAddress.createUnresolved here as some downstream libraries cannot deal with
+        // getAddress returning null.
         this.proxyAddress = new InetSocketAddress(
                 containers.ip(),
                 containers.container(PROXY_CONTAINER_NAME).port(PROXY_CONTAINER_PORT).getExternalPort());

--- a/src/main/java/com/palantir/docker/proxy/DockerProxySelector.java
+++ b/src/main/java/com/palantir/docker/proxy/DockerProxySelector.java
@@ -24,6 +24,9 @@ public final class DockerProxySelector extends ProxySelector {
     private final ProxySelector delegate;
 
     public DockerProxySelector(Cluster containers, DockerContainerInfo containerInfo, ProxySelector delegate) {
+        // ip's don't need resolution, yet without using the {@code InetSocketAddress} constructor, calling
+        // {@code InetSocketAddress#getAddress} returns {@code null} making the proxy unusable in certain downstream
+        // libraries.
         this.proxyAddress = new InetSocketAddress(
                 containers.ip(),
                 containers.container(PROXY_CONTAINER_NAME).port(PROXY_CONTAINER_PORT).getExternalPort());

--- a/src/main/java/com/palantir/docker/proxy/DockerProxySelector.java
+++ b/src/main/java/com/palantir/docker/proxy/DockerProxySelector.java
@@ -24,7 +24,7 @@ public final class DockerProxySelector extends ProxySelector {
     private final ProxySelector delegate;
 
     public DockerProxySelector(Cluster containers, DockerContainerInfo containerInfo, ProxySelector delegate) {
-        this.proxyAddress = InetSocketAddress.createUnresolved(
+        this.proxyAddress = new InetSocketAddress(
                 containers.ip(),
                 containers.container(PROXY_CONTAINER_NAME).port(PROXY_CONTAINER_PORT).getExternalPort());
         this.containerInfo = containerInfo;

--- a/src/test/java/com/palantir/docker/proxy/DockerProxySelectorTest.java
+++ b/src/test/java/com/palantir/docker/proxy/DockerProxySelectorTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
+import com.google.common.net.InetAddresses;
 import com.palantir.docker.compose.connection.Cluster;
 import com.palantir.docker.compose.connection.Container;
 import com.palantir.docker.compose.connection.ContainerCache;
@@ -31,8 +32,8 @@ import org.junit.Test;
 public class DockerProxySelectorTest {
     private static final String CLUSTER_IP = "172.17.0.1";
     private static final int PROXY_EXTERNAL_PORT = 12345;
-    private static final InetSocketAddress PROXY_ADDRESS = InetSocketAddress
-            .createUnresolved(CLUSTER_IP, PROXY_EXTERNAL_PORT);
+    private static final InetSocketAddress PROXY_ADDRESS =
+            new InetSocketAddress(InetAddresses.forString(CLUSTER_IP), PROXY_EXTERNAL_PORT);
 
     private static final String TEST_IP = "172.17.0.5";
     private static final String TEST_HOSTNAME = "some-address";


### PR DESCRIPTION
Downstream consumers may call `getAddress` and it return `null` indicating it hasn't been resolved. Despite ip addresses not needing resolution, it still makes this awkward to use as you end up having to do stuff like this:

```java
InetSocketAddress unresolved = (InetSocketAddress) getProxy().select(...).get(0);
// using the constructor performs hostname look up and initialises the field 
// for the getter `getAddress`.
InetSocketAddress resolved = 
  new InetSocketAddress(unresolved.getHostString(), unresolved.getPort());
// use resolved 
```