### PR TITLE
Update magic Dante paths to the new ones

### DIFF
--- a/changelog/@unreleased/pr-298.v2.yml
+++ b/changelog/@unreleased/pr-298.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Update usage to work with builds of Dante after 410c297862615aff77f27b99ff7151dcf20c8f71,
+    generated on the 30th of October.
+  links:
+  - https://github.com/palantir/docker-proxy-rule/pull/298

--- a/docker-proxy-rule-core/src/main/resources/docker-compose.proxy.yml
+++ b/docker-proxy-rule-core/src/main/resources/docker-compose.proxy.yml
@@ -5,7 +5,7 @@ services:
     image: vimagick/dante:latest
     ports:
       - "1080"
-    command: bash -c 'sed -i.bak "s/username //" /etc/sockd.conf && sockd -f /etc/sockd.conf -p /tmp/sockd.pid -N 10'
+    command: bash -c 'sed -i.bak "s/username //" /etc/dante/sockd.conf && sockd -f /etc/dante/sockd.conf -p /run/sockd.pid -N 10'
 
 networks:
   default:


### PR DESCRIPTION
## Before this PR
Dante referenced some static paths in its dockerfile, that DPR references in its yml file.

## After this PR
The paths have changed: https://github.com/vimagick/dockerfiles/commit/410c297862615aff77f27b99ff7151dcf20c8f71#diff-16814e8cd706b29de1ba77f011fd96f1b245ca6641b3af63b0f787af54284f90 and this PR updates the paths used in DPR to have latest pulls work.

## Possible downsides?
- It looks like vimagick is a singular user who pushes to develop directly. Should we be taking a fork and/or a different SOCKS server?
- Existing users will need to update their images.