### PR TITLE
Re-add old container logic to handle older container versions

### DIFF
--- a/changelog/@unreleased/pr-300.v2.yml
+++ b/changelog/@unreleased/pr-300.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Now try both special paths for the vimagick/dante container, handling both old and latest containers.
+  links:
+  - https://github.com/palantir/docker-proxy-rule/pull/300

--- a/docker-proxy-rule-core/src/main/resources/docker-compose.proxy.yml
+++ b/docker-proxy-rule-core/src/main/resources/docker-compose.proxy.yml
@@ -5,7 +5,7 @@ services:
     image: vimagick/dante:latest
     ports:
       - "1080"
-    command: bash -c 'sed -i.bak "s/username //" /etc/dante/sockd.conf && sockd -f /etc/dante/sockd.conf -p /run/sockd.pid -N 10'
+    command: bash -c '(sed -i.bak "s/username //" /etc/dante/sockd.conf && sockd -f /etc/dante/sockd.conf -p /run/sockd.pid -N 10) || (sed -i.bak "s/username //" /etc/sockd.conf && sockd -f /etc/dante/sockd.conf -p /tmp/sockd.pid)'
 
 networks:
   default:


### PR DESCRIPTION
## Before this PR
Naturally, our hard-coded solution fails when the image is not the latest, which happens when it is cached.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Now try both special paths for the vimagick/dante container, handling both old and latest containers.
==COMMIT_MSG==

## Possible downsides?
Can I get a sanity check that this command will actually work? I'm not massively familiar with bash. The intention is to run the former command, and try the latter if the former fails.

