### PR TITLE
Fix previous attempt at trying both execution paths

### DIFF
--- a/changelog/@unreleased/pr-301.v2.yml
+++ b/changelog/@unreleased/pr-301.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: The legacy setup path for `vimagick/dante` now works correctly.
+  links:
+  - https://github.com/palantir/docker-proxy-rule/pull/301

--- a/docker-proxy-rule-core/src/main/resources/docker-compose.proxy.yml
+++ b/docker-proxy-rule-core/src/main/resources/docker-compose.proxy.yml
@@ -5,7 +5,7 @@ services:
     image: vimagick/dante:latest
     ports:
       - "1080"
-    command: bash -c '(sed -i.bak "s/username //" /etc/dante/sockd.conf && sockd -f /etc/dante/sockd.conf -p /run/sockd.pid -N 10) || (sed -i.bak "s/username //" /etc/sockd.conf && sockd -f /etc/dante/sockd.conf -p /tmp/sockd.pid)'
+    command: bash -c '(sed -i.bak "s/username //" /etc/dante/sockd.conf && sockd -f /etc/dante/sockd.conf -p /run/sockd.pid -N 10) || (sed -i.bak "s/username //" /etc/sockd.conf && sockd -f /etc/sockd.conf -p /tmp/sockd.pid -N 10)'
 
 networks:
   default:


### PR DESCRIPTION
## Before this PR
1.1.2 had a bug on the legacy path: one of the config files that was referenced was accidentally not updated, and the `-N 10` was also left out.

## After this PR
The old path command is now correct. We copied it from the original version this time.

## Possible downsides?
Not much here. Do we need to recall 1.1.2?
