### PR TITLE
Change network name config as it is deprecated

### DIFF
--- a/changelog/@unreleased/pr-543.v2.yml
+++ b/changelog/@unreleased/pr-543.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Use non-deprecated format for specifying an external network name
+  links:
+  - https://github.com/palantir/docker-proxy-rule/pull/543

--- a/docker-proxy-junit-jupiter/src/integrationTest/resources/DockerProxyExtensionTest-services.yml
+++ b/docker-proxy-junit-jupiter/src/integrationTest/resources/DockerProxyExtensionTest-services.yml
@@ -2,5 +2,6 @@ version: '2'
 
 services:
   webserver:
-    hostname: web.server.here
+    hostname: web
+    domainname: server.here
     image: 1science/nginx

--- a/docker-proxy-rule-core/src/main/resources/docker-compose.proxy.yml
+++ b/docker-proxy-rule-core/src/main/resources/docker-compose.proxy.yml
@@ -9,5 +9,5 @@ services:
 
 networks:
   default:
-    external:
-      name: {{NETWORK_NAME}}
+    external: true
+    name: {{NETWORK_NAME}}

--- a/docker-proxy-rule-junit4/src/integrationTest/resources/DockerProxyRuleTest-services.yml
+++ b/docker-proxy-rule-junit4/src/integrationTest/resources/DockerProxyRuleTest-services.yml
@@ -2,5 +2,6 @@ version: '2'
 
 services:
   webserver:
-    hostname: web.server.here
+    hostname: web
+    domainname: server.here
     image: 1science/nginx


### PR DESCRIPTION
## Before this PR
`network.external.name` is deprecated and as a result a warning log is emitted when running `docker-compose ps -q`, which then breaks upstream ([docker-compose-rule](https://github.com/palantir/docker-compose-rule)) as commands do not filter out stderr (https://github.com/palantir/docker-compose-rule/issues/720) 
## After this PR
==COMMIT_MSG==
Use non-deprecated format for specifying an external network name
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

