### PR TITLE
Enable projects to modify the image name used by the DockerProxyExtension

### DIFF
--- a/changelog/@unreleased/pr-552.v2.yml
+++ b/changelog/@unreleased/pr-552.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Projects using DockerProxyExtension can now override the docker image
+    name used by the proxy.
+  links:
+  - https://github.com/palantir/docker-proxy-rule/pull/552

--- a/docker-proxy-junit-jupiter/src/main/java/com/palantir/docker/proxy/DockerProxyExtension.java
+++ b/docker-proxy-junit-jupiter/src/main/java/com/palantir/docker/proxy/DockerProxyExtension.java
@@ -20,6 +20,7 @@ import com.palantir.docker.compose.DockerComposeExtension;
 import com.palantir.docker.compose.configuration.ProjectName;
 import com.palantir.docker.compose.execution.DockerExecutable;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.function.Function;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -56,6 +57,20 @@ public final class DockerProxyExtension extends DockerProxyManager<DockerCompose
     }
 
     /**
+     * Creates a {@link DockerProxyExtension} using a {@link ProjectBasedDockerContainerInfo}.
+     *
+     * @param projectName The docker-compose-rule ProjectName to use to find the containers
+     * @param imageNameOverride The docker image name to use instead of the default
+     * @param classToLogFor The class using {@link DockerProxyExtension}
+     */
+    public static DockerProxyExtension fromProjectName(
+            ProjectName projectName, Class<?> classToLogFor, String imageNameOverride) {
+        return new DockerProxyExtension(
+                docker -> new ProjectBasedDockerContainerInfo(docker, projectName, Optional.of(imageNameOverride)),
+                classToLogFor);
+    }
+
+    /**
      * Creates a {@link DockerProxyExtension} using a {@link NetworkBasedDockerContainerInfo}.
      *
      * @param networkName The network name to use to find the containers
@@ -64,6 +79,20 @@ public final class DockerProxyExtension extends DockerProxyManager<DockerCompose
     public static DockerProxyExtension fromNetworkName(String networkName, Class<?> classToLogFor) {
         return new DockerProxyExtension(
                 docker -> new NetworkBasedDockerContainerInfo(docker, networkName), classToLogFor);
+    }
+
+    /**
+     * Creates a {@link DockerProxyExtension} using a {@link NetworkBasedDockerContainerInfo}.
+     *
+     * @param networkName The network name to use to find the containers
+     * @param imageNameOverride The docker image name to use instead of the default
+     * @param classToLogFor The class using {@link DockerProxyExtension}
+     */
+    public static DockerProxyExtension fromNetworkName(
+            String networkName, Class<?> classToLogFor, String imageNameOverride) {
+        return new DockerProxyExtension(
+                docker -> new NetworkBasedDockerContainerInfo(docker, networkName, Optional.of(imageNameOverride)),
+                classToLogFor);
     }
 
     @Override

--- a/docker-proxy-rule-core/src/main/java/com/palantir/docker/proxy/CachingDockerContainerInfo.java
+++ b/docker-proxy-rule-core/src/main/java/com/palantir/docker/proxy/CachingDockerContainerInfo.java
@@ -74,4 +74,9 @@ public final class CachingDockerContainerInfo implements DockerContainerInfo {
     public String getNetworkName() {
         return delegate.getNetworkName();
     }
+
+    @Override
+    public Optional<String> getImageNameOverride() {
+        return delegate.getImageNameOverride();
+    }
 }

--- a/docker-proxy-rule-core/src/main/java/com/palantir/docker/proxy/DockerContainerInfo.java
+++ b/docker-proxy-rule-core/src/main/java/com/palantir/docker/proxy/DockerContainerInfo.java
@@ -41,4 +41,10 @@ public interface DockerContainerInfo {
      * @return The network for the proxy to connect to
      */
     String getNetworkName();
+
+    /**
+     * Returns an override for the image name to use for the docker container,
+     * otherwise `vimagick/dante:latest` will get used.
+     */
+    Optional<String> getImageNameOverride();
 }

--- a/docker-proxy-rule-core/src/main/java/com/palantir/docker/proxy/NetworkBasedDockerContainerInfo.java
+++ b/docker-proxy-rule-core/src/main/java/com/palantir/docker/proxy/NetworkBasedDockerContainerInfo.java
@@ -23,10 +23,17 @@ import one.util.streamex.StreamEx;
 public final class NetworkBasedDockerContainerInfo implements DockerContainerInfo {
     private final DockerExecutable docker;
     private final String networkName;
+    private final Optional<String> imageNameOverride;
 
-    public NetworkBasedDockerContainerInfo(DockerExecutable docker, String networkName) {
+    public NetworkBasedDockerContainerInfo(
+            DockerExecutable docker, String networkName, Optional<String> imageNameOverride) {
         this.docker = docker;
         this.networkName = networkName;
+        this.imageNameOverride = imageNameOverride;
+    }
+
+    public NetworkBasedDockerContainerInfo(DockerExecutable docker, String networkName) {
+        this(docker, networkName, Optional.empty());
     }
 
     @Override
@@ -55,5 +62,10 @@ public final class NetworkBasedDockerContainerInfo implements DockerContainerInf
     @Override
     public String getNetworkName() {
         return networkName;
+    }
+
+    @Override
+    public Optional<String> getImageNameOverride() {
+        return imageNameOverride;
     }
 }

--- a/docker-proxy-rule-core/src/main/java/com/palantir/docker/proxy/ProjectBasedDockerContainerInfo.java
+++ b/docker-proxy-rule-core/src/main/java/com/palantir/docker/proxy/ProjectBasedDockerContainerInfo.java
@@ -24,10 +24,17 @@ import one.util.streamex.StreamEx;
 public final class ProjectBasedDockerContainerInfo implements DockerContainerInfo {
     private final DockerExecutable docker;
     private final ProjectName projectName;
+    private final Optional<String> imageNameOverride;
 
-    public ProjectBasedDockerContainerInfo(DockerExecutable docker, ProjectName projectName) {
+    public ProjectBasedDockerContainerInfo(
+            DockerExecutable docker, ProjectName projectName, Optional<String> imageNameOverride) {
         this.docker = docker;
         this.projectName = projectName;
+        this.imageNameOverride = imageNameOverride;
+    }
+
+    public ProjectBasedDockerContainerInfo(DockerExecutable docker, ProjectName projectName) {
+        this(docker, projectName, Optional.empty());
     }
 
     @Override
@@ -56,5 +63,10 @@ public final class ProjectBasedDockerContainerInfo implements DockerContainerInf
     @Override
     public String getNetworkName() {
         return projectName.asString() + "_default";
+    }
+
+    @Override
+    public Optional<String> getImageNameOverride() {
+        return imageNameOverride;
     }
 }

--- a/docker-proxy-rule-core/src/main/resources/docker-compose.proxy.yml
+++ b/docker-proxy-rule-core/src/main/resources/docker-compose.proxy.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   proxy:
-    image: vimagick/dante:latest
+    image: {{IMAGE_NAME}}
     ports:
       - "1080"
     command: bash -c '(sed -i.bak "s/username //" /etc/dante/sockd.conf && sockd -f /etc/dante/sockd.conf -p /run/sockd.pid -N 10) || (sed -i.bak "s/username //" /etc/sockd.conf && sockd -f /etc/sockd.conf -p /tmp/sockd.pid -N 10)'


### PR DESCRIPTION

## Before this PR
Everyone who uses DockerProxyExtension uses the same docker image for the proxy. But some projects might want to use their own container, e.g. to prevent being rate limited by docker.com.

## After this PR
==COMMIT_MSG==
Projects using DockerProxyExtension can now override the docker image name used by the proxy.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

