### PR TITLE
Change nginx docker image

### DIFF
--- a/docker-proxy-junit-jupiter/src/integrationTest/resources/DockerProxyExtensionTest-services.yml
+++ b/docker-proxy-junit-jupiter/src/integrationTest/resources/DockerProxyExtensionTest-services.yml
@@ -4,4 +4,4 @@ services:
   webserver:
     hostname: web
     domainname: server.here
-    image: 1science/nginx
+    image: nginx

--- a/docker-proxy-rule-junit4/src/integrationTest/resources/DockerProxyRuleTest-services.yml
+++ b/docker-proxy-rule-junit4/src/integrationTest/resources/DockerProxyRuleTest-services.yml
@@ -4,4 +4,4 @@ services:
   webserver:
     hostname: web
     domainname: server.here
-    image: 1science/nginx
+    image: nginx


### PR DESCRIPTION
## Before this PR
Getting errors trying to pull the old `1science/nginx` docker image
```
com.palantir.docker.compose.execution.DockerExecutionException: 'docker-compose up -d' returned exit code 18
The output was:
 webserver Pulling 
 webserver Error 
Error response from daemon: pull access denied for 1science/nginx, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

